### PR TITLE
feat: add version ldflags to Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,16 @@ RUN apk add --no-cache git ca-certificates
 # Set working directory
 WORKDIR /app
 
+# Build arguments with defaults
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+
+# Set version variables
+ENV VERSION=${VERSION}
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV BUILD_TIME=${BUILD_TIME}
+
 # Copy go mod files
 COPY go.mod go.sum ./
 
@@ -16,8 +26,13 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/gomcp ./cmd/server
+# Build the application with version info
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags "-X github.com/NP-compete/gomcp/internal/version.Version=${VERSION} \
+              -X github.com/NP-compete/gomcp/internal/version.GitCommit=${GIT_COMMIT} \
+              -X github.com/NP-compete/gomcp/internal/version.BuildTime=${BUILD_TIME}" \
+    -trimpath \
+    -o /app/bin/gomcp ./cmd/server
 
 # Final stage
 FROM alpine:latest
@@ -46,4 +61,3 @@ EXPOSE 8080
 
 # Set entrypoint
 ENTRYPOINT ["/app/gomcp"]
-

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,11 @@ lint:
 # Build Docker image
 docker-build:
 	@echo "Building Docker image..."
-	@docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+	@docker build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg BUILD_TIME="$(BUILD_TIME)" \
+		-t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 # Run Docker container
 docker-run: docker-build

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/NP-compete/gomcp/internal/api"
+	"github.com/NP-compete/gomcp/internal/constants"
 	"github.com/NP-compete/gomcp/internal/config"
 	"github.com/NP-compete/gomcp/internal/logger"
 	"github.com/NP-compete/gomcp/internal/mcp"
@@ -111,9 +112,9 @@ func runHTTPTransport(cfg *config.Config) {
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		ReadTimeout:  constants.DefaultReadTimeout,
+		WriteTimeout: constants.DefaultWriteTimeout,
+		IdleTimeout:  constants.DefaultIdleTimeout,
 	}
 
 	// Start server in a goroutine

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/NP-compete/gomcp/internal/config"
+	"github.com/NP-compete/gomcp/internal/constants"
 	"github.com/NP-compete/gomcp/internal/logger"
 	"github.com/NP-compete/gomcp/internal/mcp"
 	"github.com/NP-compete/gomcp/internal/middleware"
@@ -38,8 +38,8 @@ func NewRouter(cfg *config.Config, mcpServer *mcp.Server, oauthService *oauth.Se
 	r.Use(chimiddleware.RealIP)                    // Get real IP
 	r.Use(middleware.Recovery(*log))               // Recover from panics with logging
 	r.Use(middleware.LoggingMiddleware)            // Log all requests
-	r.Use(chimiddleware.Compress(5))               // Compress responses
-	r.Use(chimiddleware.Timeout(60 * time.Second)) // Request timeout
+	r.Use(chimiddleware.Compress(constants.DefaultCompressionLevel))               // Compress responses
+	r.Use(chimiddleware.Timeout(constants.DefaultRequestTimeout)) // Request timeout
 
 	// Apply session middleware
 	sessionSecret := cfg.GetSessionSecret()

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,47 @@
+package constants
+
+import "time"
+
+// HTTP Server Timeouts
+const (
+	// DefaultRequestTimeout is the timeout for HTTP requests
+	DefaultRequestTimeout = 60 * time.Second
+	// DefaultReadTimeout is the timeout for reading requests
+	DefaultReadTimeout = 30 * time.Second
+	// DefaultWriteTimeout is the timeout for writing responses
+	DefaultWriteTimeout = 30 * time.Second
+	// DefaultIdleTimeout is the timeout for idle connections
+	DefaultIdleTimeout = 120 * time.Second
+	// DefaultShutdownTimeout is the timeout for server shutdown
+	DefaultShutdownTimeout = 30 * time.Second
+)
+
+// Pagination
+const (
+	// DefaultPageSize is the default number of items per page
+	DefaultPageSize = 10
+	// MaxPageSize is the maximum number of items per page
+	MaxPageSize = 100
+)
+
+// Long Operation Tool
+const (
+	// MinOperationSeconds is the minimum seconds for long operation
+	MinOperationSeconds = 1
+	// MaxOperationSeconds is the maximum seconds for long operation
+	MaxOperationSeconds = 60
+)
+
+// Rate Limiting (for future use)
+const (
+	// DefaultRateLimit is the default requests per second
+	DefaultRateLimit = 100
+	// DefaultBurstSize is the default burst size for rate limiting
+	DefaultBurstSize = 20
+)
+
+// Compression
+const (
+	// DefaultCompressionLevel is the default gzip compression level
+	DefaultCompressionLevel = 5
+)

--- a/internal/mcp/server_sdk.go
+++ b/internal/mcp/server_sdk.go
@@ -153,8 +153,8 @@ func registerPromptsSDK(server *mcp.Server) {
 				if lang, ok := req.Params.Arguments["language"]; ok {
 					args.Language = lang
 				}
-				if context, ok := req.Params.Arguments["context"]; ok {
-					args.Context = context
+				if ctxArg, ok := req.Params.Arguments["context"]; ok {
+					args.Context = ctxArg
 				}
 			}
 			return prompts.GetDebugHelpPrompt(ctx, req, args)

--- a/internal/tools/long_operation_sdk.go
+++ b/internal/tools/long_operation_sdk.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/NP-compete/gomcp/internal/constants"
 	"github.com/NP-compete/gomcp/internal/logger"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -49,11 +50,11 @@ func LongOperationSDK(
 	}
 
 	// Validate input
-	if input.Seconds < 1 {
-		input.Seconds = 1
+	if input.Seconds < constants.MinOperationSeconds {
+		input.Seconds = constants.MinOperationSeconds
 	}
-	if input.Seconds > 60 {
-		input.Seconds = 60
+	if input.Seconds > constants.MaxOperationSeconds {
+		input.Seconds = constants.MaxOperationSeconds
 	}
 	if input.Task == "" {
 		input.Task = "long operation"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/NP-compete/gomcp/internal/api"
 	"github.com/NP-compete/gomcp/internal/config"
+	"github.com/NP-compete/gomcp/internal/constants"
 	"github.com/NP-compete/gomcp/internal/mcp"
 )
 
@@ -123,7 +124,7 @@ func TestInitialize(t *testing.T) {
 		t.Error("Expected pagination.support to be true")
 	}
 
-	if pag["maxPageSize"] != float64(100) {
+	if pag["maxPageSize"] != float64(constants.MaxPageSize) {
 		t.Errorf("Expected pagination.maxPageSize to be 100, got %v", pag["maxPageSize"])
 	}
 


### PR DESCRIPTION
## Summary

Add version information to Docker builds using build args and ldflags, so that the binary in the container reports correct version information.

## Changes

### Dockerfile
- Add build arguments: VERSION, GIT_COMMIT, BUILD_TIME
- Use ldflags to inject version info into the binary during build
- Set default values (dev, unknown, unknown) for local builds

### Makefile
- Update docker-build target to pass version info to docker build
- Uses existing VERSION, GIT_COMMIT, BUILD_TIME variables from Makefile

## Usage

Building Docker image...

## Verification

After building, verify version info is included:


Closes #20