### PR TITLE
fix: rename context variable to avoid shadowing

### DIFF
--- a/internal/mcp/server_sdk.go
+++ b/internal/mcp/server_sdk.go
@@ -153,8 +153,8 @@ func registerPromptsSDK(server *mcp.Server) {
 				if lang, ok := req.Params.Arguments["language"]; ok {
 					args.Language = lang
 				}
-				if context, ok := req.Params.Arguments["context"]; ok {
-					args.Context = context
+				if ctxArg, ok := req.Params.Arguments["context"]; ok {
+					args.Context = ctxArg
 				}
 			}
 			return prompts.GetDebugHelpPrompt(ctx, req, args)


### PR DESCRIPTION
Renamed the local variable `context` to `ctxArg` in server_sdk.go to avoid shadowing the standard library `context` package.

This improves code clarity and prevents potential confusion in future development.

- go vet passes
- No tests affected
